### PR TITLE
Update report.py

### DIFF
--- a/steelscript/netprofiler/core/report.py
+++ b/steelscript/netprofiler/core/report.py
@@ -378,7 +378,7 @@ class Report(object):
         """
         complete = False
         percent = 100
-        start = time.process_time ()
+        start = time.process_time()
         while (time.process_time() - start) < timeout:
             s = self.status()
 

--- a/steelscript/netprofiler/core/report.py
+++ b/steelscript/netprofiler/core/report.py
@@ -378,8 +378,8 @@ class Report(object):
         """
         complete = False
         percent = 100
-        start = time.clock()
-        while (time.clock() - start) < timeout:
+        start = time.process_time ()
+        while (time.process_time() - start) < timeout:
             s = self.status()
 
             if s['status'] == 'completed':


### PR DESCRIPTION
Fix issues of using the time.clock () method which was deprecated in Python 3.3 and has been removed in Python 3.8. The issues was discovered by Barry Constantine and he confirmed the successful test of the fix of using time.process_time () in its place.